### PR TITLE
Improved IP detection

### DIFF
--- a/MinecraftServerStatus/status.class.php
+++ b/MinecraftServerStatus/status.class.php
@@ -16,7 +16,7 @@
 
         public function getStatus($host = '127.0.0.1', $port = 25565, $version = '1.7.*') {
 
-            if (substr_count($host , '.') != 4) $host = gethostbyname($host);
+            if (preg_match("/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/", $host) !== 1) $host = gethostbyname($host);
 
             $serverdata = array();
             $serverdata['hostname'] = $host;

--- a/MinecraftServerStatus/status.class.php
+++ b/MinecraftServerStatus/status.class.php
@@ -17,15 +17,15 @@
         public function getStatus($host = '127.0.0.1', $port = 25565, $version = '1.7.*') {
 
             if (preg_match("/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/", $host) !== 1) {
-				$lookup = dns_get_record("_minecraft._tcp.". $host, DNS_SRV);
-				
-				if ( count( $lookup ) > 0 ) {
-					$host = $lookup[0]["target"];
-					$port = $lookup[0]["port"];			
-				} else {
-				    $host = gethostbyname($host);
-				}
-			}
+                $lookup = dns_get_record("_minecraft._tcp.". $host, DNS_SRV);
+
+                if ( count( $lookup ) > 0 ) {
+                    $host = $lookup[0]["target"];
+                    $port = $lookup[0]["port"];
+                } else {
+                    $host = gethostbyname($host);
+                }
+            }
 
             $serverdata = array();
             $serverdata['hostname'] = $host;

--- a/MinecraftServerStatus/status.class.php
+++ b/MinecraftServerStatus/status.class.php
@@ -16,7 +16,16 @@
 
         public function getStatus($host = '127.0.0.1', $port = 25565, $version = '1.7.*') {
 
-            if (preg_match("/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/", $host) !== 1) $host = gethostbyname($host);
+            if (preg_match("/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/", $host) !== 1) {
+				$lookup = dns_get_record("_minecraft._tcp.". $host, DNS_SRV);
+				
+				if ( count( $lookup ) > 0 ) {
+					$host = $lookup[0]["target"];
+					$port = $lookup[0]["port"];			
+				} else {
+				    $host = gethostbyname($host);
+				}
+			}
 
             $serverdata = array();
             $serverdata['hostname'] = $host;


### PR DESCRIPTION
Regex makes sure it is an actual IPv4 adress rather than also detecting a domain with 4 dots as an IP adress.