### PR TITLE
Update MinecraftServerStatus.php

### DIFF
--- a/src/MinecraftServerStatus.php
+++ b/src/MinecraftServerStatus.php
@@ -19,10 +19,12 @@ class MinecraftServerStatus {
      * @param string $host            
      * @param number $port            
      */
+    public static function query ($host = '127.0.0.1', $port = 25565, $timeout = 5) {
         // check if the host is in ipv4 format
         $host = filter_var($host, FILTER_VALIDATE_IP) ? $host : gethostbyname($host);
         
         $socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+		stream_set_timeout($socket, $timeout);
         if (! @socket_connect($socket, $host, $port)) {
             return false;
         }

--- a/src/MinecraftServerStatus.php
+++ b/src/MinecraftServerStatus.php
@@ -19,7 +19,6 @@ class MinecraftServerStatus {
      * @param string $host            
      * @param number $port            
      */
-    public static function query ($host = '127.0.0.1', $port = 25565) {
         // check if the host is in ipv4 format
         $host = filter_var($host, FILTER_VALIDATE_IP) ? $host : gethostbyname($host);
         


### PR DESCRIPTION
When not connected to a server, there is a problem that wait for a long time.

When you open a socket to set the timeout, the connection does not have to be considered if the connection is slow.

p.s. Since the article written by using the Google Translator, please understand that it may be intermittent in English.

## Original Contents (Written in Korean)

서버에 접속이 되지 않을 때, 오랜 시간 동안 기다려야 하는 문제점이 있습니다.

소켓을 열 때 timeout을 설정하여, 접속이 오래 걸릴경우 접속이 되지 않는 것으로 간주하도록 하였습니다.

p.s. 구글 번역기를 사용하여 작성한 글이기 때문에, 영어가 매끄럽지 않을 수 있으니 양해 부탁드립니다.